### PR TITLE
Avoid duplicate test compilation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,22 +189,6 @@ We use these goals frequently to keep the dependencies and plugins up-to-date:
                             <arg>-Xlint:-options</arg>
                         </compilerArgs>
                     </configuration>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>testCompile</goal>
-                            </goals>
-                            <configuration>
-                                <annotationProcessorPaths>
-                                    <path>
-                                        <groupId>org.openjdk.jmh</groupId>
-                                        <artifactId>jmh-generator-annprocess</artifactId>
-                                        <version>${jmh.version}</version>
-                                    </path>
-                                </annotationProcessorPaths>
-                            </configuration>
-                        </execution>
-                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Previously, the test compilation has been done twice in Travis CI as execution id [`default-testCompile`](https://travis-ci.org/vavr-io/vavr-benchmark/builds/628104647#L995) and [`default`](https://travis-ci.org/vavr-io/vavr-benchmark/builds/628104647#L1014):

```
[INFO] --- maven-compiler-plugin:3.8.1:testCompile (default-testCompile) @ vavr-benchmark ---
```
```
[INFO] --- maven-compiler-plugin:3.8.1:testCompile (default) @ vavr-benchmark ---
```

I believe the second one `default` is triggered by the custom execution (deleted by this PR). This customization declares explicitly the annotation processor paths by including the JMH generator. It is not necessary because in lack of processor path, the classpath is used to search the annotation processors. See https://docs.oracle.com/javase/8/docs/technotes/tools/unix/javac.html#BHCBDCJI:

> If the `-processorpath` option is not specified, then the class path is also searched for annotation processors.

Since we have JMH Generator in the test classpath, it's working fine after the deletion.